### PR TITLE
Update the tools list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Profound](https://www.tryprofound.com/) - Enterprise benchmark platform. $35M Series B (Sequoia Capital). Tracks ChatGPT, Claude, Perplexity, Gemini. Share of voice, sentiment analysis, prompt-level rankings.
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
-- [Scrunch AI](https://scrunch.ai/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
+- [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.


### PR DESCRIPTION
Removed dead projects:
- https://aimonitor.io/
- https://airank.io/
- https://amiontai.com/

Changed names/domains:
- https://deepserp.com/ -> https://peasy.so/
- https://goodie.ai/ -> https://higoodie.com/
- https://llmometrics.com/ -> https://trygeometrics.com/
- https://scrunch.ai/ -> https://scrunch.com/

New tools discovered:
- https://geckocheck.com/
- https://geoptie.com/