### PR TITLE
Add LLM Optimizer - AI brand visibility / GEO tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.
+- [LLM Optimizer](https://llmopt.metavert.io) - AI brand visibility tool (like SEO for LLMs, or GEO). Composite AI Visibility Score with per-dimension analysis across YouTube, Reddit, search, and direct LLM knowledge testing. Prioritized optimization recommendations. MCP-native access via Claude and other AI assistants.
 
 ### Enterprise SEO Platforms with GEO Features
 


### PR DESCRIPTION
Adds [LLM Optimizer](https://llmopt.metavert.io) to the **Dedicated GEO Platforms** section under Tools & Software.

**LLM Optimizer** is an AI brand visibility analytics platform — essentially SEO/GEO for how LLMs represent your brand. It provides:

- Composite AI Visibility Score (0–100) weighted across multiple analysis dimensions
- YouTube transcript authority analysis
- Reddit presence, sentiment, and training signal analysis
- Search visibility (Google AI Overviews + LLM knowledge)
- Direct LLM knowledge testing across Claude, ChatGPT, Gemini, Grok
- Prioritized optimization recommendations grounded in peer-reviewed research
- MCP-native access so AI assistants can query all reports and action items directly

**Live at:** https://llmopt.metavert.io  
**GitHub:** https://github.com/jonradoff/llmopt