### PR TITLE
Add AgentReady — free AI readiness scanner to Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [ChatGPT Rank Tracker](https://chatgptrank.com/) - Dedicated SearchGPT/ChatGPT Search visibility tracking.
 - [Create & Grow AI Overview Tracker](https://createandgrow.com/) - Focused on Google AI Overviews mention tracking.
 - [HubSpot AI Search Grader](https://www.hubspot.com/) - Free AI Search Grader tool. LLM-referred visitor segmentation. Acquired XFunnel (Jan 2025) for AI search simulations and transparency.
+- [AgentReady](https://agentready.site) - Free AI Readiness Scanner. Scores any website 0-100 for visibility to ChatGPT, Perplexity, Google AI Overviews, and Claude across 8 weighted factors (schema markup, llms.txt, bot access, content quality, AI protocols, topic clarity, authority & trust, crawl health). 60-second results, no signup. Backed by a public correlation study across 984 websites.
 - [SEMrush](https://www.semrush.com/) - AI Visibility Toolkit ($99/month per domain). Position Tracking for AI Overviews. Enterprise AIO for brand mentions, sentiment, prompt rankings across ChatGPT, Perplexity, Gemini, Claude. 100M+ prompt database.
 - [Writesonic](https://writesonic.com/) - Multi-platform tracking with content creation integration for ChatGPT, Google AI Overviews, Perplexity, Claude, Gemini.
 


### PR DESCRIPTION
AgentReady (https://agentready.site) is a free AI Readiness Scanner that gives websites a score (0-100) measuring visibility to ChatGPT, Perplexity, Google AI Overviews, and Claude. Analyzes 8 weighted factors. Backed by a public 984-website correlation study. Fits naturally in the Tools & Software section alongside HubSpot AI Search Grader and similar free tools.