### PR TITLE
Add Rank4AI to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.
+- [Rank4AI](https://rank4ai.co.uk) - UK-based AI search visibility agency using a Five Signal Model framework (Identity Clarity, Subject Authority, Meaning Architecture, Ecosystem Validation, Signal Consistency) for generative engine optimization.
 
 ### Enterprise SEO Platforms with GEO Features
 


### PR DESCRIPTION
## Summary

- Adds [Rank4AI](https://rank4ai.co.uk) to the "Dedicated GEO Platforms" section

Rank4AI is a UK-based AI search visibility agency built on a Five Signal Model framework:

1. **Identity Clarity** — clear entity definition and disambiguation
2. **Subject Authority** — structured topical depth
3. **Meaning Architecture** — RAG-ready passages, schema, llms.txt
4. **Ecosystem Validation** — third-party citation and registry alignment
5. **Signal Consistency** — temporal stability and contradiction scanning

Focused exclusively on generative engine optimization across ChatGPT, Claude, Gemini, Perplexity and Google AI Overviews.

**Website:** https://rank4ai.co.uk