### PR TITLE
Add Not Human Search to llms.txt Directory list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [Who is Using llms.txt?](https://www.llms-text.com/blog/sites-using-llms-txt) - Examples and adoption patterns across AI/ML, Developer Tools, and SaaS sectors.
 - [llms.txt Directory](https://stackfox.co/llms-txt) - Directory of llms.txt files.
 - [llms.txt Directory](https://directory.llmstxt.cloud/) - Community-driven directory of implementations.
+- [Not Human Search](https://nothumansearch.ai) - Search engine for AI agents that indexes 700+ agent-first sites ranked by agentic-readiness signals (llms.txt, OpenAPI, MCP server, ai-plugin.json). Searchable by signal presence — e.g., "show me only tools with an llms-full.txt". Hosted MCP at `/mcp` for programmatic discovery by agents.
 
 ### AI Crawlers
 


### PR DESCRIPTION
Adding [Not Human Search](https://nothumansearch.ai) alongside the existing llms.txt directories (stackfox.co/llms-txt, directory.llmstxt.cloud).

**What's different about NHS vs. other llms.txt directories:**
- **Ranked by agentic-readiness**, not alphabetical or manually curated. Sites are scored across 7 signals: llms.txt (25pt), ai-plugin (20pt), OpenAPI (20pt), structured API (15pt), MCP server (10pt), robots.txt (5pt), schema.org (5pt).
- **Search/filter by signal**: agents can query `/api/v1/search?signal=openapi` to find only tools with an OpenAPI spec.
- **700+ sites indexed** across 11 categories (developer, ai-tools, data, jobs, finance, etc.)
- **Agent-accessible**: REST API at `/api/v1/*` and hosted MCP at `https://nothumansearch.ai/mcp` (streamable-http). Agents can wire it in at build time:
  ```bash
  claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp
  ```

Fits GEO thesis: helps authors verify their llms.txt is being discovered, and helps agents find agent-first content.