### PR TITLE
Add Not Human Search to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Geoptie](https://geoptie.com/) - Helps you optimize your content for AI search engines and track your performance across multiple platforms.
 - [Goodie](https://higoodie.com/) - Leading AI-native GEO platform founded by experts from major tech companies. Comprehensive suite of GEO optimization and monitoring tools.
 - [GEOmetrics](https://trygeometrics.com/) - Hallucination detection and fixing for improved AI citation accuracy.
+- [Not Human Search](https://nothumansearch.ai/) - Open-source GEO scorer + public index. Scores any URL across 7 agentic-readiness signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org) — a transparent scoring rubric vs the proprietary dashboards above. Free REST API, embeddable SVG badges (`/badge/{domain}.svg`), and a [GitHub Action](https://github.com/unitedideas/nhs-score-check-action) that fails CI if your score drops.
 - [Otterly.AI](https://otterly.ai/) - Focused on link citation analysis for Google AI Overview and Perplexity. Timeline tracking and competitive benchmarking.
 - [Peasy](https://peasy.so/) - Specialized crawl audits and technical analysis for AI search engine visibility.
 - [Peec.ai](https://peec.ai/) - AI search visibility platform with competitive analysis and optimization recommendations.


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai/) to the **Tools & Software → Dedicated GEO Platforms** section.

Different angle from the existing entries (AthenaHQ, Bluefish, Goodie, Profound, etc.) — those are closed-source enterprise dashboards. NHS is an **open-source GEO scorer** with a transparent 7-signal rubric and a public index of ~8,000 already-scored sites.

**What it does:**
- Scores any URL across 7 agentic-readiness signals: llms.txt (25pts), ai-plugin (20), OpenAPI (20), structured API (15), MCP server (10), robots.txt (5), schema.org (5)
- Public rubric documented at https://nothumansearch.ai/guide
- Embeddable shields.io-style SVG badges at `/badge/{domain}.svg`
- [GitHub Action](https://github.com/unitedideas/nhs-score-check-action) to fail CI if your score regresses

**Why it fills a gap here:** all current GEO tools in this section focus on *citation tracking* (who does AI mention?). NHS fills the *readiness* side — *can an agent even consume my site* — with a specific scoring rubric that site owners can optimize against.

MIT license. Source: https://github.com/unitedideas/nothumansearch