### PR TITLE
Add SEO for AI to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
 - [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
+- [SEO for AI](https://getseoforai.com/) - Small-business AI visibility audits. Free checker plus a $197 remediation report covering ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.


### PR DESCRIPTION
Adding SEO for AI under Dedicated GEO Platforms. It is a small-business-focused AEO audit service with a free citation checker and a $197 full report.

- Site: https://getseoforai.com/
- Free checker: https://getseoforai.com/checker
- Blog: https://getseoforai.com/blog/

Entry placed alphabetically between Scrunch and ZipTie.