### PR TITLE
Add Parse to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Goodie](https://higoodie.com/) - Leading AI-native GEO platform founded by experts from major tech companies. Comprehensive suite of GEO optimization and monitoring tools.
 - [GEOmetrics](https://trygeometrics.com/) - Hallucination detection and fixing for improved AI citation accuracy.
 - [Otterly.AI](https://otterly.ai/) - Focused on link citation analysis for Google AI Overview and Perplexity. Timeline tracking and competitive benchmarking.
+- [Parse](https://parse.gl/) - AI brand visibility analytics tracking how brands appear in ChatGPT and Google AI Overviews. Parse Score benchmarks, competitor battlecards, citation diagnostics, and 577K+ brands tracked.
 - [Peasy](https://peasy.so/) - Specialized crawl audits and technical analysis for AI search engine visibility.
 - [Peec.ai](https://peec.ai/) - AI search visibility platform with competitive analysis and optimization recommendations.
 - [Profound](https://www.tryprofound.com/) - Enterprise benchmark platform. $35M Series B (Sequoia Capital). Tracks ChatGPT, Claude, Perplexity, Gemini. Share of voice, sentiment analysis, prompt-level rankings.


### PR DESCRIPTION
Adds Parse (https://parse.gl/) to the Dedicated GEO Platforms section. Parse tracks brand mentions across ChatGPT and Google AI Overviews with daily updates across 577K+ brands.