### PR TITLE
Add AI Visibility Monitor to Tools & Software / Open Source Data / Evals

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
+- [AI Visibility Monitor](https://github.com/WorkSmartAI-alt/ai-visibility-monitor) - Open-source Python toolkit for tracking how often ChatGPT, Claude, and Perplexity cite your domain. MIT licensed.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
 #### llms.txt Generators


### PR DESCRIPTION
Adding AI Visibility Monitor, an open-source Python toolkit for tracking ChatGPT, Claude, and Perplexity citations of a given domain.

Why this fits the Open Source Data / Evals subsection specifically:
- It is open-source (MIT licensed) and self-hosted, matching the spirit of the existing entries (AI Product Bench, GEO/AEO Tracker)
- It runs locally on your own credentials with no SaaS dependency
- It targets the specific GEO outcome of measuring citation rate by AI engine over time

Repo: https://github.com/WorkSmartAI-alt/ai-visibility-monitor
License: MIT
Status: Active development, currently used in production for tracking work-smart.ai and a small number of client domains.

Inserted alphabetically between AI Product Bench and GEO/AEO Tracker. Happy to move the entry if a different section is a better fit.