### PR TITLE
Add TinyTools AI Robots.txt Generator to AI Crawlers section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [The Rise of AI Crawlers](https://vercel.com/blog/the-rise-of-the-ai-crawler) - Analysis of 1.3B crawler requests.
 - [How OpenAI Crawls Websites](https://www.withdaydream.com/library/how-openai-crawls-and-indexes-your-website) - Technical breakdown.
 - [AI Crawlers Can't Execute JavaScript](https://prerender.io/blog/how-to-optimize-your-website-for-ai-crawlers/) - Critical limitation analysis.
+- [TinyTools AI Robots.txt Generator](https://tinytools-smoky.vercel.app/ai-robots-txt-generator/) - Free browser-based generator for robots.txt rules targeting AI crawlers (GPTBot, ClaudeBot, Google-Extended, PerplexityBot, CCBot, and more). No signup, runs entirely client-side.
 
 ### Structured Data
 


### PR DESCRIPTION
Hi! Adding **TinyTools AI Robots.txt Generator** to the AI Crawlers section.

**What it is:** A free, browser-based tool that generates robots.txt rules specifically targeting AI crawlers — GPTBot, ClaudeBot, Google-Extended, PerplexityBot, CCBot, Bytespider, Meta-ExternalAgent, Anthropic-AI, and more. Useful for site owners managing GEO/AI visibility decisions about which crawlers to allow or block.

**Why it fits this list:** Crawler control is a fundamental piece of GEO strategy — deciding which AI engines should ingest your content directly impacts visibility in ChatGPT, Perplexity, Google AI Overviews, etc. The existing AI Crawlers section covers the *theory* (which crawlers exist, what they do); this adds a *tool* practitioners can actually use to act on that knowledge.

**Details:**
- 100% client-side (no signup, no data collection)
- Open source
- Free, no rate limits
- Part of [TinyTools](https://tinytools-smoky.vercel.app/), a collection of single-purpose web utilities

Happy to adjust placement or wording — thanks for maintaining this list!