### PR TITLE
Add Dualmark to llms.txt Generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.
+- [Dualmark](https://github.com/dodopayments/dualmark) - Open-source AEO/GEO infrastructure. Generates `/llms.txt` plus markdown twins of every page (served via HTTP content negotiation when an AI crawler UA is detected). TypeScript adapters for Astro, Next.js, and Cloudflare Workers. Includes a conformance CLI (`dualmark verify <url>`). Apache 2.0, npm provenance attested.
 - [llmstxtgenerator.org](https://llmstxtgenerator.org/) - Web-based generator.
 - [WordLift Generator](https://wordlift.io/generate-llms-txt/) - WordPress integration.
 


### PR DESCRIPTION
Adds [Dualmark](https://github.com/dodopayments/dualmark) under **Tools & Software → Utilities & Generators → llms.txt Generators**.

**What it is:** Open-source AEO/GEO infrastructure. Generates `/llms.txt` plus markdown twins of every page (served via HTTP content negotiation when an AI crawler UA is detected). TypeScript adapters for Astro, Next.js, and Cloudflare Workers. Includes a conformance CLI (`bunx @dualmark/cli verify <url>`).

- **Live llms.txt:** https://dualmark.dev/llms.txt
- **Spec:** [AEO Specification v1.0](https://github.com/dodopayments/dualmark/tree/main/spec) — RFC-2119 formatted, framework-agnostic
- **License:** Apache 2.0
- **Supply-chain:** npm provenance attested (Sigstore-signed), verifiable with `npm audit signatures`

Placed alphabetically between Apify and llmstxtgenerator.org. Happy to adjust placement or wording.