### PR TITLE
Add GeoScore — free open-source GEO + SEO audit tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [GeoScore](https://geoscoreapp.pages.dev) - Free, open-source instant GEO + SEO audit tool. 39 checks covering E-E-A-T signals, structured data, llms.txt, FAQ schema, author attribution, and citation-friendly patterns. No login, no tracking. Built on Cloudflare Workers. ([GitHub](https://github.com/sprawf/geoscore))
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
Adding [GeoScore](https://geoscoreapp.pages.dev) to the Open Source Data / Evals section.

**What it is:** A free, open-source instant GEO + SEO audit tool that checks 39 signals for AI search visibility — the signals ChatGPT, Perplexity, and Gemini use to decide which sites to cite.

**GEO checks include:**
- E-E-A-T markers (author pages, expertise signals)
- - FAQ / HowTo / Article schema
- - llms.txt support
- - Citation-friendly content patterns
- - Structured data completeness
**Why it fits here:**
- Purpose-built for GEO auditing (not a general SEO tool)
- - Free and open source (MIT, GitHub: https://github.com/sprawf/geoscore)
- - No login, no tracking, no account needed
- - Built on Cloudflare Workers (stateless, $0/month to self-host)
- - Results in ~30 seconds