### PR TITLE
Add AgentGrade to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@
 
 Purpose-built platforms for AI search optimization, monitoring, and brand visibility:
 
+- [AgentGrade](https://agentgrade.com/) - Scanner for AI agent readiness across 70+ checks (MCP, x402, llms.txt, OpenAPI, content negotiation). Free per-check report with remediation links to a Knowledge Base. Public leaderboard, CLI, MCP server, and GitHub Action.
 - [AthenaHQ](https://www.athenahq.ai/) - Y Combinator-backed. Founded by ex-Google Search and DeepMind leaders. Unified GEO scoring. Claims 70+ customers with 10× AI traffic increases.
 - [Bluefish AI](https://bluefishai.com/) - $5M funded. Specializes in brand safety and source attribution. "Source graph" showing how Wikipedia, forums, PDFs influence outputs. AI ad campaigns.
 - [GeckoCheck](https://geckocheck.com/) - Platform that helps merchants and brands optimize visibility, dominate AIsearch results, and deliver answers to billions of daily shoppers.


### PR DESCRIPTION
Adds AgentGrade to the "Dedicated GEO Platforms" section.

AgentGrade is a free scanner that grades websites on AI agent readiness across 70+ checks — covering MCP, x402, llms.txt, OpenAPI, content negotiation, identity, and infrastructure signals. Each check returns pass/fail with a remediation hint linked to a Knowledge Base article. Public leaderboard ("The Agentic Web Index") ranks the top 100 sites. Also ships a CLI (`agentgrade-cli` on npm), a remote MCP server (`agentgrade.com/mcp`), and a GitHub Action.

- Site: https://agentgrade.com
- Leaderboard: https://agentgrade.com/leaderboard/
- KB: https://agentgrade.com/kb
- GitHub Action: https://github.com/marketplace/actions/agentgrade-scan

Placed alphabetically before AthenaHQ.
