### PR TITLE
Add agent-readiness-cli to Open Source Data / Evals

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [agent-readiness-cli](https://github.com/sspoisk/agent-readiness-cli) - Open-source Python CLI scoring any URL on a 0-100 scale for AI agent (ChatGPT, Claude, Perplexity) readiness. Checks llms.txt, canonical, robots.txt for AI bots, schema.org, hreflang, content density. MIT, pip install agent-readiness-cli.
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
## What

Adds [`agent-readiness-cli`](https://github.com/sspoisk/agent-readiness-cli) to the **Open Source Data / Evals** section.

## Why it fits

`agent-readiness-cli` is an open-source Python CLI that scores any URL on a 0-100 scale for how readable it is to AI agents (ChatGPT, Claude, Perplexity). It's directly aligned with this list's mission — a measurement utility for GEO/AEO practitioners.

**Checks performed:**
- `llms.txt` presence and structure
- Canonical tag
- `robots.txt` AI bot directives (GPTBot, ClaudeBot, PerplexityBot, etc.)
- Schema.org / JSON-LD structured data
- `hreflang` for multi-language pages
- Content density / token economy

## Details

- **License:** MIT
- **Install:** `pip install agent-readiness-cli`
- **GitHub:** https://github.com/sspoisk/agent-readiness-cli
- **PyPI:** https://pypi.org/project/agent-readiness-cli/
- **Tests:** 13/13 passing, std-lib only (no extra deps), Python 3.10+
- **Usage:** `agent-readiness-cli https://example.com` → prints overall score + per-criterion breakdown

## Placement

Single-line addition in `Open Source Data / Evals` subsection, after `GEO/AEO Tracker` (sibling open-source eval tool).

Happy to adjust wording or placement if maintainer prefers.