### PR TITLE
Add MiN8T llms.txt as a production reference under Technical Implementation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@
 - [Integrate GEO with SEO](https://searchengineland.com/integrate-geo-seo-453351) - Strategies for unified traditional and AI search optimization.
 - [10-Step Guide to GEO](https://www.superlines.io/articles/generative-engine-optimization-geo-guide-2025) - Systematic approach to implementing GEO.
 - [LLMO: 10 Ways to Work Your Brand Into AI Answers](https://ahrefs.com/blog/llm-optimization/) - Practical tactics for improving AI citations.
+- [MiN8T llms.txt — Production Example](https://min8t.com/llms.txt) - Live llms.txt implementation with AI bot allowlist, citation-guidance section, and per-tool indexing hints. Reference for the [llms.txt protocol](https://llmstxt.org/) in production.
 
 ## Case Studies
 


### PR DESCRIPTION
Adds one entry under **Technical Implementation**:

```markdown
- [MiN8T llms.txt — Production Example](https://min8t.com/llms.txt) - Live llms.txt implementation with AI bot allowlist, citation-guidance section, and per-tool indexing hints. Reference for the [llms.txt protocol](https://llmstxt.org/) in production.
```

The section currently has guides *about* llms.txt but no link to a live production implementation. Adding one — readers can read the convention guide, then look at a working example.

Disclosure: I authored the llms.txt.