### PR TITLE
Add friendly4AI to AI platforms list in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 
 - [AthenaHQ](https://www.athenahq.ai/) - Y Combinator-backed. Founded by ex-Google Search and DeepMind leaders. Unified GEO scoring. Claims 70+ customers with 10× AI traffic increases.
 - [Bluefish AI](https://bluefishai.com/) - $5M funded. Specializes in brand safety and source attribution. "Source graph" showing how Wikipedia, forums, PDFs influence outputs. AI ad campaigns.
+- [friendly4AI](https://friendly4.ai/) - GEO Scanner producing two scores per scan: AI-Readiness (technical crawl/parse/understand audit, free, no account) and AI Visibility (whether ChatGPT, Gemini, Claude, and Perplexity recommend the site). 40+ GEO/AEO parameters with evidence-based, prioritized fixes.
 - [GeckoCheck](https://geckocheck.com/) - Platform that helps merchants and brands optimize visibility, dominate AIsearch results, and deliver answers to billions of daily shoppers.
 - [GenRank](https://genrank.io/) - Timeline visualization and competitor benchmarking for AI visibility trends.
 - [Geoptie](https://geoptie.com/) - Helps you optimize your content for AI search engines and track your performance across multiple platforms.


### PR DESCRIPTION
Adds friendly4AI to Dedicated GEO Platforms, alphabetically between Bluefish AI and GeckoCheck. friendly4AI (https://friendly4.ai) is a GEO Scanner producing an AI-Readiness score (free) and an AI Visibility score across 40+ GEO/AEO parameters with evidence-based recommendations. Single addition; follows the existing list format.