### PR TITLE
Add auto-geo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
+- [auto-geo](https://github.com/shadowresearch/auto-geo) - Open-source CLI that audits pages for AI-citation readiness and measures whether ChatGPT, Claude, Gemini, Perplexity, and Grok cite a domain.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
 #### llms.txt Generators


### PR DESCRIPTION
auto-geo is an open-source CLI that audits pages for AI-citation readiness and measures whether ChatGPT, Claude, Gemini, Perplexity, and Grok cite a domain.

Disclosure: I work on auto-geo at Shadow.

The project is MIT-licensed and open source: https://github.com/shadowresearch/auto-geo

Added under Tools & Software > Utilities & Generators > Open Source Data / Evals, in alphabetical order.