### PR TITLE
Add Authorship Strategy to Research & Papers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [AI Platform Citation Patterns](https://www.tryprofound.com/blog/ai-platform-citation-patterns) - Analysis of how ChatGPT, Google AI Overviews, and Perplexity cite sources differently. *Wikipedia dominates ChatGPT at 47.9% of top citations; Reddit appears heavily in Gemini and Perplexity.*.
 - [Conductor 2026 AEO/GEO Benchmarks Report](https://www.conductor.com/academy/aeo-geo-benchmarks-report/) - Industry's first large-scale AEO/GEO analysis across 13,770 domains, 21.9M searches, and 17M AI responses. *Key finding: ChatGPT drives 87.4% of AI referral traffic; AI referral conversions are 2× higher than traditional sources.*.
 - [State of AI Search Optimization 2026](https://www.growth-memo.com/p/state-of-ai-search-optimization-2026) - Kevin Indig's comprehensive analysis of LLM citation patterns and visibility factors. *Reports 24% of ChatGPT responses generated without fetching online content; content under 3 months old is 3× more likely to be cited.*.
+- [Authorship Strategy](https://github.com/shimo4228/authorship-strategy) - DOI-registered research repository on how authorship and attribution behave under AI-mediated diffusion. *Records a strategy doctrine as ten tactical ADRs (llms.txt, knowledge graphs, identifier federation) plus preliminary observations from the author's own CC0-published traffic data — a single-author longitudinal case study.*.
 
 ### Knowledge Conflicts & Retrieval
 


### PR DESCRIPTION
Adds [Authorship Strategy](https://github.com/shimo4228/authorship-strategy), a DOI-registered research repository ([10.5281/zenodo.20263316](https://doi.org/10.5281/zenodo.20263316)) on how authorship and attribution behave under AI-mediated diffusion. It records a normative strategy as ten tactical ADRs (covering llms.txt, JSON-LD knowledge graphs, and identifier federation) plus an empirical layer with preliminary observations from the author's own CC0-published GitHub traffic data. The empirical claims are framed as preliminary, single-author longitudinal observations. I am the author.