### PR TITLE
Add Grounding Citation Analysis study (Foundational Research)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [AI Platform Citation Patterns](https://www.tryprofound.com/blog/ai-platform-citation-patterns) - Analysis of how ChatGPT, Google AI Overviews, and Perplexity cite sources differently. *Wikipedia dominates ChatGPT at 47.9% of top citations; Reddit appears heavily in Gemini and Perplexity.*.
 - [Conductor 2026 AEO/GEO Benchmarks Report](https://www.conductor.com/academy/aeo-geo-benchmarks-report/) - Industry's first large-scale AEO/GEO analysis across 13,770 domains, 21.9M searches, and 17M AI responses. *Key finding: ChatGPT drives 87.4% of AI referral traffic; AI referral conversions are 2× higher than traditional sources.*.
 - [State of AI Search Optimization 2026](https://www.growth-memo.com/p/state-of-ai-search-optimization-2026) - Kevin Indig's comprehensive analysis of LLM citation patterns and visibility factors. *Reports 24% of ChatGPT responses generated without fetching online content; content under 3 months old is 3× more likely to be cited.*.
+- [Grounding Citation Analysis](https://organikpi.com/tools/grounding-citation-analysis/) - Reproducible study decoding 42,971 AI-search citations across 6 platforms (Google AI Mode, Gemini, ChatGPT, Perplexity, Copilot, Grok). *Parses #:~:text= URL fragments to reveal the exact sentences AI engines quote from source pages, with positional and sentence-length analysis.*.
 
 ### Knowledge Conflicts & Retrieval
 


### PR DESCRIPTION
Adding **Grounding Citation Analysis** to *Research & Papers > Foundational Research*.

It is a reproducible, open study that decodes **42,971 AI-search citations** across 6 platforms (Google AI Mode, Gemini, ChatGPT, Perplexity, Copilot, Grok) by parsing `#:~:text=` URL fragments to reveal the exact sentences AI engines quote from source pages, with positional and sentence-length analysis.

- Fits the existing Foundational Research style (study + finding).
- Not a duplicate; complements the GEO/AEO Tracker already listed under Open Source Data / Evals.
- Source repo: https://github.com/danishashko/grounding-citation-analysis