### PR TITLE
Add Citeerbaar to Specialized GEO Agencies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,6 +326,7 @@ These platforms are frequently cited by AI engines - building presence here impr
 Agencies offering dedicated generative engine optimization services:
 
 - [Avenue Z](https://avenuez.com/) - Serves FinTech, B2B SaaS, HealthTech, DTC eCommerce.
+- [Citeerbaar](https://www.citeerbaar.nl/) - Dutch (NL/BE) GEO/AEO agency for SMBs, hospitality, events and webshops. AI-citation scans and llms.txt implementation.
 - [First Page Sage](https://firstpagesage.com/) - Top-rated GEO agency serving Salesforce, Logitech. Specializes in B2B SaaS, medtech, manufacturing.
 - [Growth Plays](https://www.growthplays.com/) - Data-driven GEO and content strategies.
 - [Ignite Visibility](https://ignitevisibility.com/) - Full-service digital marketing with GEO capabilities.


### PR DESCRIPTION
Adds Citeerbaar (https://www.citeerbaar.nl/), a GEO/AEO agency based in the Netherlands serving Dutch and Belgian SMBs, hospitality, events and webshops. It is the first NL/EU-focused agency in this section.

- Placed alphabetically between Avenue Z and First Page Sage
- - Follows the existing "- [Name](url) - Description." format
- - Citeerbaar publishes its own llms.txt and llms-full.txt and offers AI-citation measurement