### PR TITLE
Add NotFair — open-source Claude Code skills for GEO, SEO, and paid ads

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads (~2.9k stars, MIT). Covers [GEO optimization](https://github.com/nowork-studio/NotFair/tree/main/seo), [keyword research](https://github.com/nowork-studio/NotFair/tree/main/seo), [schema markup](https://github.com/nowork-studio/NotFair/tree/main/seo), and [content writing](https://github.com/nowork-studio/NotFair/tree/main/seo) via live data from Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
Thanks for maintaining this list — it's a great reference for the GEO space.

I'd like to add **NotFair** ([github.com/nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)), an open-source (MIT) set of Claude Code agent skills for SEO, GEO, Google Ads, and Meta Ads. It has around ~2.9k stars and is actively maintained.

The GEO angle: NotFair includes skills for site-level GEO analysis, keyword research with AI-search intent, meta tag and schema markup generation, E-E-A-T content writing, and geo targeting optimization. These run as Claude Code agents pulling live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so the analysis is grounded in real account data rather than static reports.

I've placed it in **Tools & Software > Utilities & Generators > Open Source Data / Evals** alongside the GEO/AEO Tracker, since both are open-source tools you run yourself. Happy to move it to a different subsection or trim the description if you'd prefer a shorter format.