### PR TITLE
Add AI Crawler Bots

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 ### Utilities & Generators
 
 #### Open Source Data / Evals
+- [AI Crawler Bots](https://github.com/TryGeoSuite/ai-crawler-bots) - Open-source CLI and GitHub Action that audits robots.txt for AI crawler access, computes an AI-visibility score, and reads access logs to confirm which AI bots crawled.
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 


### PR DESCRIPTION
Adds **AI Crawler Bots**, an MIT-licensed, zero-dependency Node CLI + GitHub Action with a curated JSON list of AI crawler user-agents. It audits robots.txt for AI-bot access, computes an AI-visibility score, tests live reachability, and reads access logs to confirm which AI bots actually crawled.

- Repo: https://github.com/TryGeoSuite/ai-crawler-bots
- npm: https://www.npmjs.com/package/@geosuite/ai-crawler-bots

Placed alphabetically under **Utilities & Generators → Open Source Data / Evals**. Thanks for maintaining this list!