### PR TITLE
Add Recommd to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.
+- [Recommd](https://recommd.com) - AI visibility audit for local businesses. Checks whether ChatGPT, Perplexity, and Google AI Overviews recommend a given business or a competitor, returning a 0-100 visibility score and a plain-English fix plan. Free basic check, no signup.
 
 ### Enterprise SEO Platforms with GEO Features
 


### PR DESCRIPTION
Adding **Recommd** to **Tools & Software → Dedicated GEO Platforms**.

Recommd is a free AI-visibility audit aimed at the local-business / SMB angle of GEO: it queries ChatGPT, Perplexity, and Google AI Overviews with the question a customer would actually ask and reports whether the business is recommended or a competitor is named instead, plus a plain-English fix plan and a 0-100 visibility score.

It fills the local/SMB gap alongside the existing enterprise-leaning trackers in this section. Entry follows the section's `- [Name](url) - Description` format. Happy to adjust placement or wording to fit the list's conventions.