### PR TITLE
Add MaxAEO AI Visibility MCP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [MaxAEO AI Visibility MCP](https://github.com/maxaeo/maxaeo-ai-visibility-mcp) - Open-source, local-first MCP server for GEO/AEO and AI visibility audits. Checks llms.txt, AI crawler access, robots, sitemap, canonical, metadata, noindex, and JSON-LD for Claude, Codex, Cursor, and other MCP clients. No LLM API calls or telemetry by default.
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
Adds MaxAEO AI Visibility MCP to the Open Source Data / Evals section.

MaxAEO AI Visibility MCP is an open-source, local-first MCP server for GEO/AEO and AI visibility audits. It checks public website signals such as llms.txt, AI crawler access, robots, sitemap, canonical, metadata, noindex, and JSON-LD for Claude, Codex, Cursor, and other MCP clients.

Install:

```bash
npx -y maxaeo-ai-visibility-mcp
```

Boundaries:
- Local/public-web audit only.
- No MaxAEO internal API calls.
- No LLM API calls.
- No hidden telemetry by default.
