### PR TITLE
Add open-geo — AI-answer visibility tracker (Claude Code skill)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [open-geo](https://github.com/Pupok462/open-geo) - Open-source (MIT) AI-answer visibility tracker that runs as a Claude Code skill. Measures how a brand surfaces in Google AI Overview, ChatGPT search, Claude search, Gemini, and Yandex Alice by driving a real logged-in browser and reading the rendered answer. Outputs an answer→sources→citations visibility funnel, a top-domains leaderboard, a React dashboard, and PDF reports (EN/RU/ZH/AR).
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
Adds [open-geo](https://github.com/Pupok462/open-geo) to **Tools & Software → Utilities & Generators → Open Source Data / Evals** (alphabetical order within the subsection).

open-geo is an open-source (MIT) GEO visibility tracker that runs as a Claude Code skill: it measures how a brand surfaces inside AI answers (Google AI Overview, ChatGPT search, Claude search, Gemini, Yandex Alice) by driving a real logged-in browser and reading the rendered answer, and outputs an answer→sources→citations visibility funnel, a top-domains leaderboard, a React dashboard, and PDF reports (EN/RU/ZH/AR). It is on-topic for this list, actively maintained, and fits alongside the other open-source visibility tools in this subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)