### PR TITLE
Add Revenue Grader to Tools & Software

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Profound](https://www.tryprofound.com/) - Enterprise benchmark platform. $35M Series B (Sequoia Capital). Tracks ChatGPT, Claude, Perplexity, Gemini. Share of voice, sentiment analysis, prompt-level rankings.
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
+- [Revenue Grader](https://getrevenuegrader.com/) - Free page-level tool that scores whether ChatGPT, Claude, and Perplexity would cite a URL, with nine subscores and specific fixes. No signup for the first scan.
 - [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.


### PR DESCRIPTION
Adds Revenue Grader under **Tools & Software → Dedicated GEO Platforms**: a free page-level tool that scores whether ChatGPT, Claude, and Perplexity would cite a URL, returning nine subscores and specific fixes. No signup for the first scan.

Inserted alphabetically and formatted to match the surrounding entries. Kept the description factual (no funding or customer claims). Public URL: https://getrevenuegrader.com