### PR TITLE
Add Citeable (llms.txt + schema.org generator) to llms.txt Generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.
 - [llmstxtgenerator.org](https://llmstxtgenerator.org/) - Web-based generator.
 - [WordLift Generator](https://wordlift.io/generate-llms-txt/) - WordPress integration.
+- [Citeable](https://citeable.eu/) - Crawls a site and generates an llms.txt, llms-full.txt, and Q&A schema.org markup to make it citable by AI answer engines. One-time payment.
 
 
 


### PR DESCRIPTION
Adds **Citeable** ([citeable.eu](https://citeable.eu)) to the list.

Citeable is a Generative Engine Optimization tool: you paste a site URL, it crawls the public pages and generates an `llms.txt`, an `llms-full.txt`, and Q&A `schema.org` markup (JSON-LD) that make the site readable and citable by AI answer engines (ChatGPT, Perplexity, Gemini, Claude). It also dogfoods its own output at https://citeable.eu/llms.txt and https://citeable.eu/llms-full.txt.

- Live and usable (free citability scan; one-time payment for generation).
- Single entry, placed in the most relevant section, matching the existing format.