### PR TITLE
Add KusiGEO to the list of AI visibility & GEO tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,8 @@
 
 ### Dedicated GEO Platforms
 
+- [KusiGEO](https://kusiai.es/) — AI visibility audit tool for ChatGPT, Gemini, Perplexity and AI Overviews; measures brand mentions, entity clarity and citation readiness.
+
 Purpose-built platforms for AI search optimization, monitoring, and brand visibility:
 
 - [AthenaHQ](https://www.athenahq.ai/) - Y Combinator-backed. Founded by ex-Google Search and DeepMind leaders. Unified GEO scoring. Claims 70+ customers with 10× AI traffic increases.


### PR DESCRIPTION
Hi!

I would like to suggest adding KusiGEO to the list. It's a specialized AI visibility and semantic audit tool built for extracting true citation readiness and brand mentions from LLMs like ChatGPT, Perplexity, and Google AI Overviews.

Thank you for curating this awesome list!