### PR TITLE
Add marketingskills/seo to Other Awesome Lists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -352,6 +352,7 @@ Agencies offering dedicated generative engine optimization services:
 - [Awesome-GEO by DavidHuji](https://github.com/DavidHuji/Awesome-GEO) - Research-focused GEO paper collection.
 - [Awesome SEO](https://github.com/teles/awesome-seo) - Traditional SEO resources that complement GEO strategies.
 - [Awesome AI GTM](https://github.com/ong/awesome-ai-gtm) - AI-powered Go-To-Market tools, including an AI Visibility & GEO section.
+- [Marketingskills SEO](https://github.com/coreyhaines31/seo) - SEO agent skills for AI workflows: 20+ SKILL.md files covering technical SEO, programmatic SEO, schema markup, content optimization, and GEO. Install via `curl -fsSL marketingskills.net/seo | bash`.
 
 ## Footnotes
 


### PR DESCRIPTION
Adds [marketingskills/seo](https://github.com/coreyhaines31/seo) to the Related Resources > Other Awesome Lists section.

marketingskills/seo is an open-source collection of 20+ SKILL.md files for AI agents, covering technical SEO, programmatic SEO, schema markup, content optimization, and generative engine optimization (GEO). Installed via `curl -fsSL marketingskills.net/seo | bash`.

This is a complementary resource for GEO practitioners looking to equip AI coding agents (Claude Code, Codex, Copilot) with SEO capabilities. The repo is MIT-licensed and actively maintained.

Related GEO resources already listed: Awesome SEO (traditional SEO), Awesome AI GTM (AI go-to-market tools). marketingskills/seo fills the gap for *hands-on SEO agent skills* that can be installed and run immediately.