### PR TITLE
Add Chinese AI platforms coverage (DeepSeek, Doubao, Qwen, Kimi)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,11 @@
 - [Perplexity Ranking Factors Deep Dive](https://firstpagesage.com/seo-blog/perplexity-ai-optimization-ranking-factors-and-strategy/) - Detailed analysis of Perplexity's 3-layer reranking system.
 - [59+ Perplexity Ranking Patterns](https://metehan.ai/blog/perplexity-ai-seo-59-ranking-patterns/) - Browser-level code analysis revealing specific ranking factors.
 
+#### Chinese AI Platforms (DeepSeek, Doubao, Qwen, Kimi)
+
+- [Which AI Search Platforms Matter in China?](https://visibilityatlas.com/blog/which-ai-search-platforms-matter-in-china/) - Overview of DeepSeek, Doubao, Qwen, Kimi, Tencent Yuanbao, and Baidu AI surfaces, with a repeatable cross-platform brand testing protocol.
+- [DeepSeek vs Doubao vs Qwen Brand Visibility](https://visibilityatlas.com/blog/deepseek-vs-doubao-vs-qwen-brand-visibility/) - How brand mentions, citations, and competitor substitution differ across China's major AI assistants.
+
 ### Technical Implementation
 
 - [AI Optimization Technical Guide](https://searchengineland.com/ai-optimization-how-to-optimize-your-content-for-ai-search-and-agents-451287) - Comprehensive technical overview of content optimization for AI systems.
@@ -335,6 +340,7 @@ Agencies offering dedicated generative engine optimization services:
 - [RevenueZen](https://revenuezen.com/) - B2B GEO specialists for growth-stage companies.
 - [Siege Media](https://www.siegemedia.com/) - Content-focused GEO with comprehensive optimization strategies.
 - [Victorious](https://victorious.com/) - Award-winning for technical precision. Structured content, rich snippets, prompt-based optimizations.
+- [Visibility Atlas](https://visibilityatlas.com/) - China-focused GEO consultancy. Audits brand visibility and citations across DeepSeek, Doubao, Qwen, Kimi, and Baidu AI for international brands.
 - [WebFX](https://www.webfx.com/) - Full-service with proprietary OmniSEO™ platform. Tracks client/competitor performance across AI-driven search.
 
 #### Agency Directories & Reviews


### PR DESCRIPTION
This list currently has platform-specific guidance for Google AI Overviews, ChatGPT Search, and Perplexity, but nothing on the Chinese AI search ecosystem — DeepSeek, Doubao, Qwen, Kimi, Tencent Yuanbao, and Baidu's AI surfaces — which operates on a different source layer (WeChat, Zhihu, Xiaohongshu, Baidu index) and answers hundreds of millions of users.

This PR adds:

1. A **Chinese AI Platforms** subsection under Platform-Specific Optimization with two educational resources: a platform overview with a repeatable cross-platform brand testing protocol, and a comparison of how brand mentions and citations differ across DeepSeek, Doubao, and Qwen.
2. One agency entry (Visibility Atlas, China-focused GEO consultancy) in the existing Specialized GEO Agencies section, in alphabetical order and matching the entry format.

Disclosure: I run Visibility Atlas. The linked articles are editorial guides with sources, not sales pages — happy to swap in additional non-affiliated China GEO resources if maintainers prefer, or to drop the agency entry and keep only the platform guides.