### PR TITLE
Add seo-geo-audit — free open-source GEO/SEO audit CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [seo-geo-audit](https://github.com/lireking/seo-geo-audit) - Dependency-free CLI that audits a site for AI-search (GEO) readiness by parsing the JS-less server HTML, alongside classic SEO, Core Web Vitals, and Search Console opportunity reports. Local, free, markdown output.
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
Adds **seo-geo-audit** to Tools & Software → Open Source Data / Evals.

It fits right next to the GEO/AEO Tracker entry: a free, dependency-free CLI that audits a site for AI-search (GEO) readiness by parsing the JS-less server HTML — plus classic SEO, Core Web Vitals and Search Console opportunity reports, all as markdown. It fills a gap in the list, which is otherwise almost entirely paid SaaS platforms — this is a local, $0, open-source option.

Repo: https://github.com/lireking/seo-geo-audit