### PR TITLE
Add aeo-scan (Open Source Data / Evals)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 ### Utilities & Generators
 
 #### Open Source Data / Evals
+- [aeo-scan](https://github.com/iSimplifyMe/aeo-scan) - Open-source (MIT) CLI auditing pages against The AEO Standard (versioned 100-point AEO rubric, CC BY 4.0): source-parse + rendered-HTML modes, JSON-LD validation with @graph support, CI exit codes.
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 


### PR DESCRIPTION
Adds [aeo-scan](https://github.com/iSimplifyMe/aeo-scan) under Tools & Software → Utilities & Generators → Open Source Data / Evals, in alphabetical position. Open-source (MIT) CLI that audits pages against [The AEO Standard](https://github.com/iSimplifyMe/aeo-standard) — a published, versioned 100-point AEO rubric (CC BY 4.0, canonical at isimplifyme.com/labs/aeo-standard): source-parse + rendered-HTML modes, JSON-LD validation with @graph support, CI exit codes.

Disclosure: I maintain both repositories — self-submission. Happy to adjust placement or wording to fit the list's conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)