### PR TITLE
Add WhereDoIRank.ai to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
 - [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
+- [WhereDoIRank.ai](https://wheredoirank.ai/) - Free public leaderboard of which brands ChatGPT, Claude, Gemini and Perplexity recommend, by category. Published methodology, the verbatim model answer stored behind every score, and no paid placement.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.


### PR DESCRIPTION
Adds WhereDoIRank.ai to **Tools & Software → Dedicated GEO Platforms**, inserted alphabetically.

**What it is:** a free, public leaderboard of which brands ChatGPT, Claude, Gemini and Perplexity recommend, by category. Currently 113 measured categories.

**Why it may be worth listing alongside the existing entries:** every other platform in that section is a paid product, so this fills a gap for anyone wanting to see what GEO measurement actually looks like before buying one. Three specifics that are checkable rather than claimed:

- The methodology is published, including its limitations: https://wheredoirank.ai/methodology
- Every score links to the verbatim stored model answer that produced it, so a reported rank can be audited rather than trusted
- It is free to read with no signup, and no brand can pay to change a position

Happy to move it to Monitoring & Analytics instead, shorten the description, or drop it if it is not a fit for the list. Thanks for maintaining this.