### PR TITLE
Add AISO Tools to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@
 
 Purpose-built platforms for AI search optimization, monitoring, and brand visibility:
 
+- [AISO Tools](https://aisotools.com/audit) - Free AI visibility audit, no signup or credit card. Scores 0-100 on how often ChatGPT recommends a given tool across five category prompts, and names the competitors it surfaces instead. Backed by a 798-tool AI directory.
 - [AthenaHQ](https://www.athenahq.ai/) - Y Combinator-backed. Founded by ex-Google Search and DeepMind leaders. Unified GEO scoring. Claims 70+ customers with 10× AI traffic increases.
 - [Bluefish AI](https://bluefishai.com/) - $5M funded. Specializes in brand safety and source attribution. "Source graph" showing how Wikipedia, forums, PDFs influence outputs. AI ad campaigns.
 - [GeckoCheck](https://geckocheck.com/) - Platform that helps merchants and brands optimize visibility, dominate AIsearch results, and deliver answers to billions of daily shoppers.


### PR DESCRIPTION
Adds one line to **Tools & Software → Dedicated GEO Platforms**, alphabetically first.

```
- [AISO Tools](https://aisotools.com/audit) - Free AI visibility audit, no signup or credit card. Scores 0-100 on how often ChatGPT recommends a given tool across five category prompts, and names the competitors it surfaces instead. Backed by a 798-tool AI directory.
```

**Why this section rather than Utilities & Generators:** the two subsections there are "Open Source Data / Evals" and "llms.txt Generators", and this is neither — it's a hosted visibility scorer, which is what every entry in Dedicated GEO Platforms is.

**What's actually differentiated:** every current entry in that section is paid or gated. The one free grader on the list (HubSpot) sits down in Enterprise SEO Platforms. This runs with no signup and no credit card, so it's the only entry someone can evaluate in ten seconds.

**I verified the claims today rather than pasting marketing copy.** Three unauthenticated runs against the live endpoint:

| Tool | Category | Score | Mentions |
|---|---|---|---|
| Notion | Productivity | 100 | 5/5 |
| Jasper | Writing | 96 | 5/5 |
| Linear | Productivity | 0 | 0/5 |

The Linear result is the useful one — it shows the score discriminates rather than flattering everything you type in. (Linear is a project-management tool, so a generic "best AI productivity tools" prompt set doesn't surface it.) The 798-tool figure is the live count on the site today, not a rounded-up claim.

**Disclosure: I maintain AISO Tools.** Happy to move it to Utilities & Generators, cut the description down, drop the directory clause, or close this if a self-submission isn't wanted — no hard feelings either way.

One unrelated thing I hit while reading the contribution rules: the `## Contribute` section links to `CONTRIBUTING.md`, which 404s — there's no such file in the repo. Flagging it since it's the first thing a new contributor clicks. Glad to open a separate PR adding one if useful.