### PR TITLE
Add SeenForAI to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
 - [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
+- [SeenForAI](https://seenfor.ai/) - Daily brand monitoring across 7 LLMs, including native coverage of Chinese models (Doubao, Kimi, DeepSeek). Share of Voice, sentiment, citation extraction, and multi-model voting to verify hallucinations. Free tier; paid plans from $49/month.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.


### PR DESCRIPTION
Adds SeenForAI to **Tools & Software → Dedicated GEO Platforms**.

SeenForAI tracks brand visibility daily across 7 LLMs — ChatGPT, Claude, Gemini and Perplexity, plus the Chinese models Doubao, Kimi and DeepSeek — reporting Share of Voice against competitors, sentiment, and the exact URLs each model cites. It uses multi-model voting consensus to filter out hallucinated mentions rather than trusting a single model's self-report. Free tier; paid plans from $49/month.

The differentiator relative to the platforms already listed in this section is native Chinese LLM coverage (Doubao, Kimi, DeepSeek), queried in Chinese and translated back.

Entry inserted alphabetically between Scrunch and ZipTie, matching the surrounding `- [Name](url) - Description.` format. Link verified (HTTP 200).

Disclosure: I'm the author of SeenForAI.
