### PR TITLE
Add Koalr to dedicated GEO platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Geoptie](https://geoptie.com/) - Helps you optimize your content for AI search engines and track your performance across multiple platforms.
 - [Goodie](https://higoodie.com/) - Leading AI-native GEO platform founded by experts from major tech companies. Comprehensive suite of GEO optimization and monitoring tools.
 - [GEOmetrics](https://trygeometrics.com/) - Hallucination detection and fixing for improved AI citation accuracy.
+- [Koalr](https://www.koalr.ai/) - AI visibility intelligence platform tracking brand mentions, citations, and share of voice across major AI answer engines.
 - [Otterly.AI](https://otterly.ai/) - Focused on link citation analysis for Google AI Overview and Perplexity. Timeline tracking and competitive benchmarking.
 - [Peasy](https://peasy.so/) - Specialized crawl audits and technical analysis for AI search engine visibility.
 - [Peec.ai](https://peec.ai/) - AI search visibility platform with competitive analysis and optimization recommendations.


### PR DESCRIPTION
Adds Koalr to the dedicated GEO platforms section. Koalr tracks brand mentions, citations, and share of voice across major AI answer engines, so it fits alongside the existing AI visibility monitoring tools.