### PR TITLE
Add Agent-Directed Manipulation: a testable definition of where the line falls

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [Adversarial SEO for LLMs](https://arxiv.org/abs/2406.18382) - Hidden text boosts mentions 2.5× in AI answers. *Demonstrates manipulation techniques, highlighting the importance of legitimate optimization approaches.*.
 - [Ranking Manipulation for Conversational Search](https://arxiv.org/abs/2406.03589) - Prompt injection for ranking manipulation. *Shows how on-page content can influence AI rankings through strategic text structures.*.
 - [Persistent Pre-Training Poisoning of LLMs](https://arxiv.org/abs/2410.13722) - Long-term poisoning attack strategies. *Suggests why maintaining fresh, authoritative content matters as AI systems update their training data.*.
+- [Agent-Directed Manipulation](https://github.com/perpensum/agent-directed-manipulation) - Testable definition separating manipulation from legitimate machine-readable optimization. *Draws the line the research above describes: two mechanically decidable axes and 18 conformance cases, 13 of which expect no finding, so structured data, llms.txt and ordinary marketing copy are never flagged.*.
 
 
 


### PR DESCRIPTION
Adds one line to **Research & Papers → Adversarial & Security Research**.

## Why here

That section already documents the attacks: hidden text boosting mentions 2.5×, corpus poisoning, prompt injection for ranking manipulation. Each entry is annotated with why a legitimate practitioner should care.

**This entry is the measurement counterpart.** It is not another attack paper — it is a definition of where the line falls, written so that anyone measuring the same page reaches the same verdict.

That matters for this audience specifically. GEO practitioners are the people most likely to be **wrongly accused** as detection tooling proliferates: publishing structured data, `llms.txt`, and clear machine-readable copy is exactly the legitimate work this field is about, and a careless detector flags all of it.

So the definition is built to protect that work:

- Two mechanically decidable axes — region (first-party / third-party) and visibility (visible / hidden) — and **no subjective axis**. No verdict turns on whether a claim sounds overblown
- **23 conformance cases, 18 of which expect no finding.** Ordinary ad copy, structured data, `llms.txt`, screen-reader text, genuine reviews, and responsive/print CSS are all explicitly clean, with test cases pinning each one down
- A dependency-free reference implementation, so a practitioner can check their own pages: `curl -s https://yoursite.com | node reference/scan.mjs`
- Stated limits instead of a blanket claim of detection: external CSS is not fetched, runtime JavaScript is not evaluated, region detection is inference

CC BY 4.0 for the definition, MIT for the code. Implementing it requires no permission, notification, or certification from anyone.

## Disclosure

I am the author. Perpensum is building third-party evaluation of AI agent purchasing decisions, so I have a commercial interest in this definition being adopted. There is no paid product, and the definition is deliberately implementable by competitors.

The repository was published this week. **If the list prefers entries with more history, or if you would rather keep this section to peer-reviewed research only, please close this** — I would rather the section keep its shape.