### PR TITLE
Add CiteCheckup to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.
+- [CiteCheckup](https://www.citecheckup.com/) - Free webpage audit that scores seven published citation-readiness signals and suggests practical content fixes for AI search.
 
 ### Enterprise SEO Platforms with GEO Features
 


### PR DESCRIPTION
## Summary
- Adds CiteCheckup to the Dedicated GEO Platforms section.
- CiteCheckup is a free, public webpage audit with a deterministic seven-signal core score.
- The listing is submitted with the tool owner's authorization and does not claim to guarantee AI citations or rankings.

## Scope
- One README entry only; no code changes.