### PR TITLE
Add Engagemii to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 
 - [AthenaHQ](https://www.athenahq.ai/) - Y Combinator-backed. Founded by ex-Google Search and DeepMind leaders. Unified GEO scoring. Claims 70+ customers with 10× AI traffic increases.
 - [Bluefish AI](https://bluefishai.com/) - $5M funded. Specializes in brand safety and source attribution. "Source graph" showing how Wikipedia, forums, PDFs influence outputs. AI ad campaigns.
+- [Engagemii](https://engagemii.com/) - Scores any site 0-10 for AI answer engine visibility, free and with no signup. 34.7M+ sites scored worldwide, 15.1M verified US businesses. Citation tracking across ChatGPT, Claude and Gemini at $14.99/month; bulk data licensing via Snowflake Marketplace.
 - [GeckoCheck](https://geckocheck.com/) - Platform that helps merchants and brands optimize visibility, dominate AIsearch results, and deliver answers to billions of daily shoppers.
 - [GenRank](https://genrank.io/) - Timeline visualization and competitor benchmarking for AI visibility trends.
 - [Geoptie](https://geoptie.com/) - Helps you optimize your content for AI search engines and track your performance across multiple platforms.


### PR DESCRIPTION
Adds Engagemii to `### Dedicated GEO Platforms`, placed alphabetically between Bluefish AI and GeckoCheck, following the section's house style (trailing slash, one to two sentences, concrete facts).

Engagemii scores any website 0-10 on how findable and citable it is to AI answer engines, and tracks whether those engines actually cite you. It is the low-cost end of this section: the score is free with no signup, and citation tracking is $14.99/month.

Scale, since other entries cite funding or customer counts: 34.7M+ websites scored worldwide, 15.1M of them verified US businesses, from our own crawling and analysis. Public data sample: https://huggingface.co/datasets/Engagemii/ai-visibility-sample

Disclosure: I work on Engagemii.