### PR TITLE
Add Open Datasets subsection: weekly AI Visibility Index (SaaS + crypto)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -227,6 +227,11 @@ McKinsey projects agentic commerce will reach $3-5 trillion by 2030. Major playe
 - [LLM Tracking Tools Overview](https://nightwatch.io/blog/llm-tracking-tools/) - Feature comparison across major tracking platforms.
 - [AI Search Visibility Tools Directory](https://www.rankability.com/blog/best-ai-search-visibility-tracking-tools/) - Comprehensive directory of tracking tools.
 
+### Open Datasets
+
+- [AI Visibility Index — SaaS](https://dabyte.ai/) - Weekly open dataset (JSON/CSV, CC BY 4.0) of share-of-answer for 20 SaaS brands across ChatGPT, Perplexity and Gemini, with a verbatim archive of every measurement.
+- [AI Visibility Index — Crypto](https://dablock.ai/) - Same weekly share-of-answer methodology for 24 crypto/Web3 brands; frozen versioned prompt panels, full time series via free API.
+
 
 
 ## Newsletters & Blogs


### PR DESCRIPTION
Adds an **Open Datasets** subsection under Monitoring & Analytics with two free, open-data AI-visibility indexes:

- **[AI Visibility Index — SaaS](https://dabyte.ai/)** — weekly share-of-answer for 20 SaaS brands across ChatGPT, Perplexity and Gemini. JSON/CSV/markdown mirrors, no key, CC BY 4.0.
- **[AI Visibility Index — Crypto](https://dablock.ai/)** — same methodology for 24 crypto/Web3 brands.

Why it fits this list: the Monitoring & Analytics section currently links guides and commercial platforms, but no open datasets. These publish the raw measurements themselves — frozen versioned prompt panels, a verbatim archive of every past measurement (so any delta can be recomputed), disclosed measurement resolution, and an `is_client` flag on every record so editorial independence is verifiable rather than claimed. Data is also mirrored on [GitHub](https://github.com/creanlab/ai-visibility-index) and [Hugging Face](https://huggingface.co/datasets/crean/ai-visibility-index).

Disclosure: I publish these indexes. Placement in them cannot be bought, and both are free for any use including commercial.