### PR TITLE
Add Seeno (AI brand visibility platform)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
 - [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
+- [Seeno](https://seeno.ai/) - AI brand visibility platform tracking ChatGPT, Perplexity, Gemini, Claude and Google AI Overviews. Vertical benchmarks for real estate, hotels and law firms built on published research of thousands of scanned answers.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.


### PR DESCRIPTION
This PR adds Seeno (https://seeno.ai) to the tools list.

Disclosure: I am the founder. Seeno is an AI brand visibility platform that tracks how brands appear in answers from ChatGPT, Perplexity, Gemini, Claude and Google AI Overviews. It focuses on vertical benchmarks (real estate, hotels, law firms, B2B SaaS) and publishes open industry research built on thousands of scanned AI answers: https://seeno.ai/research

Placement follows the existing ordering and formatting of the list. Happy to adjust wording.