### PR TITLE
Add Corank to dedicated GEO platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 
 - [AthenaHQ](https://www.athenahq.ai/) - Y Combinator-backed. Founded by ex-Google Search and DeepMind leaders. Unified GEO scoring. Claims 70+ customers with 10× AI traffic increases.
 - [Bluefish AI](https://bluefishai.com/) - $5M funded. Specializes in brand safety and source attribution. "Source graph" showing how Wikipedia, forums, PDFs influence outputs. AI ad campaigns.
+- [Corank](https://corank.ai) - AI agent-powered AEO/GEO platform offering a free audit and tracking visibility across ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews.
 - [GeckoCheck](https://geckocheck.com/) - Platform that helps merchants and brands optimize visibility, dominate AIsearch results, and deliver answers to billions of daily shoppers.
 - [GenRank](https://genrank.io/) - Timeline visualization and competitor benchmarking for AI visibility trends.
 - [Geoptie](https://geoptie.com/) - Helps you optimize your content for AI search engines and track your performance across multiple platforms.


### PR DESCRIPTION
Adds Corank to **Tools & Software → Dedicated GEO Platforms**.

The public homepage offers a free audit and describes visibility tracking across ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews. The entry follows the surrounding one-line format and makes one addition.

Disclosure: I’m affiliated with Corank.