### PR TITLE
Add Kurage GEO (Japanese GEO audit platform)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.
+- [Kurage GEO](https://kurage.exbridge.jp/kgeo.php) - Japanese-language GEO audit and AI-search visibility monitoring. Deterministically diagnoses missing llms.txt / JSON-LD and suggests fixes (no LLM needed for the audit). Free tier available.
 
 ### Enterprise SEO Platforms with GEO Features
 


### PR DESCRIPTION
Adds **Kurage GEO** under *Tools & Software → Dedicated GEO Platforms*.

- URL: https://kurage.exbridge.jp/kgeo.php
- What it is: a Japanese-language GEO audit and AI-search visibility monitor. It deterministically checks a site for missing `llms.txt` / JSON-LD and suggests fixes (the audit itself uses no LLM), with a free tier.
- Why it fits: the list is currently English/Western-centric; this adds coverage for Japanese-language GEO, an underrepresented area.

Disclosure: I maintain this project. Entry follows the existing `- [Name](URL) - description.` format. Thanks for the great list!