### PR TITLE
Add Elmo - open-source, self-hosted AI visibility platform

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
+- [Elmo](https://github.com/elmohq/elmo) - Open-source, self-hosted AI visibility platform (MIT). Measures how ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews mention, cite, and describe a brand, with competitor benchmarking and citation analysis. BYOK, runs on your own infrastructure via Docker Compose, and every metric definition is auditable in the source.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
 #### llms.txt Generators


### PR DESCRIPTION
## New addition: Elmo

Adding one open-source tool under **Tools & Software → Utilities & Generators → Open Source Data / Evals**.

**[Elmo](https://github.com/elmohq/elmo)** is an open-source, self-hosted platform for tracking and improving AI visibility (AEO / GEO / LLMO — the name comes from LLMO). It measures how ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews mention, cite, and describe a brand, and benchmarks that against competitors.

**Disclosure:** I maintain Elmo. Happy to adjust the wording, trim the description, or move it to a different section if you'd prefer it elsewhere.

### Why it fits this list

- Squarely in scope: prompt-level tracking of brand mentions and citations across the major answer engines, plus competitor benchmarking.
- **Open source (MIT) and self-hosted** — a free alternative to the commercial platforms already listed under Dedicated GEO Platforms. BYOK, runs on your own infrastructure via Docker Compose, and you own your data.
- Auditable by design: every metric definition is readable in the source, so you can verify exactly how a visibility score is computed rather than trusting a black box.
- Actively maintained since August 2025, ~235 stars, MIT licensed.
- Complements the existing [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) and [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) entries as another free, self-hosted option.

**Links:** [Repo](https://github.com/elmohq/elmo) · [Site](https://www.elmohq.com/) · [Live demo](https://demo.elmohq.com) · [Docs](https://www.elmohq.com/docs)

### Guideline compliance

- One item, one PR; single-line diff to `readme.md`.
- Entry format matches the list: `- [Name](link) - Description.` — description starts uppercase, ends with a period, no hard-wrapping.
- Inserted in alphabetical position within its subsection (after AI Product Bench, before GEO/AEO Tracker).
- Not a duplicate — Elmo isn't currently in the list.
- All three links verified live (HTTP 200).
- Ran `awesome-lint`: my line is clean. The 6 reported errors are all pre-existing and unrelated (missing `contributing.md`, badge/license detection, a casing issue on the Rankability Blog entry, and duplicate `geo-conference.com` links).
