### PR TITLE
Add seo-geo-skill to Open Source Data / Evals

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [seo-geo-skill](https://github.com/asale-ai/seo-geo-skill) - Open-source agent skills that audit a site for GEO and classic SEO from inside a coding agent. AI-crawler reachability checks, passage-level citability scoring, llms.txt validation and generation, schema and citation-gap analysis. Single Rust binary, no Python; installs into Claude Code, Codex, Cursor and 75+ agents. MIT.
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
Adds one entry under Tools & Software > Utilities & Generators > Open Source Data / Evals.

**What it is:** an open-source (MIT) set of agent skills that run a GEO + SEO audit from inside a coding agent, rather than as a hosted dashboard. The execution layer is a single Rust static binary, so there is no Python or pip in the install path, and it installs into Claude Code, Codex, Cursor and 75+ other agents via npx skills.

**Why it fits this list:** it covers several things the list already tracks separately - AI-crawler reachability against robots.txt, llms.txt validation and generation, schema detection and generation, and passage-level citability scoring for answer engines - and most of it runs with no accounts and no API keys, so it is usable without a paid platform.

Disclosure: I am the author. Happy to move it to a different subsection or shorten the description if you would prefer - the existing subsections did not have an obvious slot for an open-source audit tool.