### PR TITLE
Add Mydentify AI Crawler Access Checker to open-source GEO tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [Mydentify AI Crawler Access Checker](https://mydentify.com/tools/ai-crawler-access-checker) - Check whether documented AI search and user-retrieval crawlers can reach a page, and distinguish robots.txt rules from observed HTTP responses.
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
Adds one factual entry to Tools & Software → Utilities & Generators → Open Source Data / Evals.

Mydentify AI Crawler Access Checker checks whether documented AI search and user-retrieval crawlers can reach a page, distinguishes robots.txt rules from observed HTTP responses, and states the limits of non-provider-IP probes.

Disclosure: I maintain Mydentify and the linked tool. The tool page and MIT-licensed source repository are public. No reciprocal link or engagement is requested.