### PR TITLE
Add WeaveAI Cite to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
 - [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
+- [WeaveAI Cite](https://www.weaveai.dev/products/cite) - Autonomous AEO content engine that drafts and publishes content built to earn citations in AI answers.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.


### PR DESCRIPTION
Adds WeaveAI Cite to the Dedicated GEO Platforms section (alphabetical position, existing entry format).

Disclosure: I'm affiliated with WeaveAI — this is our product. The description sticks to what the product does; happy to adjust wording or placement if the maintainers prefer.