### PR TITLE
Add Arobis llms.txt Generator to llms.txt Generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.
 - [llmstxtgenerator.org](https://llmstxtgenerator.org/) - Web-based generator.
 - [WordLift Generator](https://wordlift.io/generate-llms-txt/) - WordPress integration.
+- [Arobis llms.txt Generator](https://arobis.ai/llms-txt-generator) - Free browser-based generator, no crawler and no signup. Runs fully client-side so nothing entered leaves the page. Outputs spec-faithful structure (H1, blockquote summary, annotated link sections) rather than a sitemap dump.
 
 
 


### PR DESCRIPTION
Adds a free llms.txt generator to the existing llms.txt Generators list.

Differentiators from the three tools currently listed: it runs entirely client-side (no crawler, no server round trip, nothing typed leaves the page), and it has no signup or email gate. Output follows the spec structure (H1, blockquote summary, annotated link sections) rather than converting a sitemap.

Disclosure: I am the author. Happy to adjust the wording or drop the entry if it does not fit the list's criteria.