### PR TITLE
Add askchat.studio to GEO Service Providers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -325,6 +325,7 @@ These platforms are frequently cited by AI engines - building presence here impr
 
 Agencies offering dedicated generative engine optimization services:
 
+- [askchat.studio](https://askchat.studio/) - GEO for local wellness businesses: med spas, day spas, and salons. Free check shows which sources AI cites for a given city.
 - [Avenue Z](https://avenuez.com/) - Serves FinTech, B2B SaaS, HealthTech, DTC eCommerce.
 - [First Page Sage](https://firstpagesage.com/) - Top-rated GEO agency serving Salesforce, Logitech. Specializes in B2B SaaS, medtech, manufacturing.
 - [Growth Plays](https://www.growthplays.com/) - Data-driven GEO and content strategies.


### PR DESCRIPTION
Adding askchat.studio under Specialized GEO Agencies (alphabetical position).

**What it is:** GEO for local wellness businesses — med spas, day spas and salons. The list currently covers B2B SaaS, enterprise and eCommerce providers, so this fills a gap on the local-services side.

**Why it may be useful here:** the free check reports which sources an AI answer actually cites for a given city, not just whether a brand is mentioned — useful for anyone researching how citation sources vary by locality.

One line added, existing entries untouched, formatting matches the surrounding list. Happy to adjust the wording or move it to a different section if you prefer.