### PR TITLE
Add Scaleify to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
 - [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
+- [Scaleify](https://scaleify.co/seo-ai-visibility) - Early-access AI visibility platform combining public-page readiness audits, tracked buyer prompts, Search Console query data, and prioritized implementation workflows.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.


### PR DESCRIPTION
Adds one factual entry to Tools & Software → Dedicated GEO Platforms.\n\nScaleify combines public-page AI-visibility readiness auditing, tracked buyer prompts, Search Console query evidence, and prioritized implementation workflows. The linked product page is public and returns HTTP 200.\n\nDisclosure: I am affiliated with Scaleify. No reciprocal link, payment, or engagement is requested.