### PR TITLE
Add OpenGEO (open-source GEO standard, Chinese AI engine coverage)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Geoptie](https://geoptie.com/) - Helps you optimize your content for AI search engines and track your performance across multiple platforms.
 - [Goodie](https://higoodie.com/) - Leading AI-native GEO platform founded by experts from major tech companies. Comprehensive suite of GEO optimization and monitoring tools.
 - [GEOmetrics](https://trygeometrics.com/) - Hallucination detection and fixing for improved AI citation accuracy.
+- [OpenGEO](https://github.com/cangqiaoGEO) - Open-source GEO standard and toolkit: brand-facts spec (RFC-governed), evidence-based audit natively covering Chinese AI engines (Doubao, Qwen, DeepSeek, Tencent Yuanbao), agent skills, and a community-built visibility index. MIT / CC BY-SA.
 - [Otterly.AI](https://otterly.ai/) - Focused on link citation analysis for Google AI Overview and Perplexity. Timeline tracking and competitive benchmarking.
 - [Peasy](https://peasy.so/) - Specialized crawl audits and technical analysis for AI search engine visibility.
 - [Peec.ai](https://peec.ai/) - AI search visibility platform with competitive analysis and optimization recommendations.


### PR DESCRIPTION
Adds **OpenGEO** to *Tools & Software → Dedicated GEO Platforms*.

OpenGEO (https://github.com/cangqiaoGEO) is an open-source GEO **standard + toolkit**, complementary to the platforms listed:

- Brand-facts spec (RFC-governed single source of truth for brand claims)
- Evidence-based brand audit with **native coverage of Chinese AI engines** (Doubao, Qwen, DeepSeek, Tencent Yuanbao) — to our knowledge the only open-source project auditing these engines today
- Agent skills with offline contract evals, and a community-built public visibility index
- Licensing: MIT (code) / CC BY-SA 4.0 (spec & docs)

Entry follows the existing bullet format, placed alphabetically within the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)