### PR TITLE
Add isready.ai to Open Source Data / Evals

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Major SEO platforms that have added AI search optimization capabilities:
 #### Open Source Data / Evals
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
+- [isready.ai](https://github.com/isreadyai/isreadyai) - Open-source CLI (`npx isreadyai`) that checks whether AI crawlers can fetch and read a page.
 
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.


### PR DESCRIPTION
Add isready.ai under Tools & Software → Utilities & Generators → Open Source Data / Evals, next to AI Product Bench and GEO/AEO Tracker.

It is a free CLI that checks whether an AI crawler can fetch and read the page.