### PR TITLE
Add aeoptimize: local/CI content-readiness lint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,9 @@ Major SEO platforms that have added AI search optimization capabilities:
 - [AI Product Bench](https://github.com/amplifying-ai/ai-product-bench) - Benchmark for AI product visibility.
 - [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+#### Local / CI linters
+- [aeoptimize](https://github.com/cucuwang/aeoptimize) - Deterministic local/CI content-readiness lint for static sites and docs. The score is a versioned heuristic for catching regressions, not a forecast of ranking or AI citation.
+
 #### llms.txt Generators
 - [Apify Generator](https://apify.com/jakub.kopecky/llmstxt-generator) - Scraping-based generator.
 - [llmstxtgenerator.org](https://llmstxtgenerator.org/) - Web-based generator.


### PR DESCRIPTION
## Why

aeoptimize is a free MIT CLI/Action that lints static sites and docs for machine-readable structure, sourced claims, JSON-LD hygiene, and indexing controls.

It belongs under Tools → Utilities, not Dedicated GEO Platforms: it does not track ChatGPT/Perplexity visibility.

## Listing text

The description states the score is a versioned heuristic for regressions, not a forecast of ranking or AI citation.

## Links

- https://github.com/cucuwang/aeoptimize
- npm: aeoptimize@0.6.2