### PR TITLE
Add Merlonix to Tools & Software

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.
+- [Merlonix](https://merlonix.com/ai-answer-presence/) - Tracks whether ChatGPT, Perplexity and other answer engines cite your brand and how they describe you. Includes free AI answer-presence and agent-readiness checkers (can AI crawlers reach and correctly read your site), a free tier, and a hosted MCP server.
 
 ### Enterprise SEO Platforms with GEO Features
 


### PR DESCRIPTION
Adds **Merlonix** to **Tools & Software**, alongside the dedicated AI-visibility monitoring peers already listed (Knowatoa, ZipTie, Profound).

[Merlonix](https://merlonix.com/ai-answer-presence/) tracks whether ChatGPT, Perplexity and other answer engines cite your brand and how they describe you. It's differentiated by two **free** checkers — an [AI answer-presence checker](https://merlonix.com/tools/answer-presence/) and an [agent-readiness checker](https://merlonix.com/tools/agent-readiness/) (verifies AI crawlers/agents can reach and correctly read your site) — plus a free tier and a hosted MCP server for agent workflows.

Single line, appended to the Tools & Software list following the same `- [Name](url) - description.` format.
