### PR TITLE
Add Asked Thrice to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@
 
 Purpose-built platforms for AI search optimization, monitoring, and brand visibility:
 
+- [Asked Thrice](https://askedthrice.com/) - One-time AI visibility audits that report counts instead of a score. Derives buyer questions from your site and asks OpenAI, Gemini and Claude three times each, keeping the raw answers as evidence. Free first audit, no signup.
 - [AthenaHQ](https://www.athenahq.ai/) - Y Combinator-backed. Founded by ex-Google Search and DeepMind leaders. Unified GEO scoring. Claims 70+ customers with 10× AI traffic increases.
 - [Bluefish AI](https://bluefishai.com/) - $5M funded. Specializes in brand safety and source attribution. "Source graph" showing how Wikipedia, forums, PDFs influence outputs. AI ad campaigns.
 - [GeckoCheck](https://geckocheck.com/) - Platform that helps merchants and brands optimize visibility, dominate AIsearch results, and deliver answers to billions of daily shoppers.


### PR DESCRIPTION
Adds [Asked Thrice](https://askedthrice.com/) to **Tools & Software → Dedicated GEO Platforms**, inserted alphabetically before AthenaHQ.

**Disclosure:** this is my own tool. I opened #113 as a suggestion so a maintainer could decide, and sent this PR as well since the issue queue is long — please close either one if you would rather not list it.

**Note on the name:** this PR originally said "LLM Audit". The product was renamed to Asked Thrice on 2026-08-30, because "LLM audit" is a generic phrase shared with three unrelated companies and an assistant asked about it described someone else. Same tool, same people, new name and domain.

**Why it fits the section:** it is purpose-built for AI search visibility, and it differs from the platforms already listed in what it reports. Instead of a single 0-100 score, it reports counts with their total ("named in 3 of 12 buyer questions") and keeps the raw model answers as evidence, because the same prompt asked twice does not always return the same brands. The name comes from that: three runs per model.

**What the entry claims, and where it comes from:**

- Derives buyer questions from the site being audited, then asks OpenAI, Gemini and Claude, three runs per provider.
- Free first audit with no signup, at https://askedthrice.com/check and on the home page.
- Method and provider lineup: https://askedthrice.com/methodology

No badges, no marketing adjectives, one line, same format as the surrounding entries.