### PR TITLE
Add Scope to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [Profound](https://www.tryprofound.com/) - Enterprise benchmark platform. $35M Series B (Sequoia Capital). Tracks ChatGPT, Claude, Perplexity, Gemini. Share of voice, sentiment analysis, prompt-level rankings.
 - [Rankscale](https://rankscale.ai/) - AI-first SEO platform with GEO capabilities for enterprise brands.
 - [Rankshift](https://rankshift.com/) - Position tracking and visibility monitoring for AI-powered search platforms.
+- [Scope](https://scope.online/) - AI visibility platform that monitors brand recommendations across ChatGPT, Claude, Gemini, Perplexity, Google AI and Copilot, with an MCP server for agents.
 - [Scrunch](https://scrunch.com/) - Agent Experience Platform (AXP) for making websites legible to AI engines. Monitoring and active optimization.
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.


### PR DESCRIPTION
Adds Scope (https://scope.online/) under Dedicated GEO Platforms, alphabetically after Rankshift and before Scrunch.

Factual one-liner. Live product + hosted MCP at https://scope.online/mcp (registry `online.scope/mcp`). Complements classic SEO rather than replacing it.
