### PR TITLE
Add Greadme to Dedicated GEO Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Purpose-built platforms for AI search optimization, monitoring, and brand visibi
 - [ZipTie](https://ziptie.ai/) - Brand visibility monitoring across generative AI platforms with detailed breakdowns.
 - [Knowatoa](https://knowatoa.com/) - AI search analytics platform tracking brand mentions across ChatGPT, Claude, and Perplexity.
 - [Daydream](https://www.withdaydream.com/) - AI visibility optimization platform with focus on content discoverability.
+- [Greadme](https://www.greadme.com/) - Website audits that check whether AI systems can access and cite a site, validate structured data, and turn every finding into a fix you can copy. Schema Validator and AI Access Checker are free with no signup.
 
 ### Enterprise SEO Platforms with GEO Features
 


### PR DESCRIPTION
Adds Greadme to Tools & Software → Dedicated GEO Platforms, appended at the bottom to match the existing order.

What it does: audits a page or whole site for SEO, performance, accessibility, security and structured data; the AI Access Checker reports whether AI systems can access and read a site (robots.txt, llms.txt, noindex, snippet restrictions, client-side-only rendering); the AI Visibility Checker reports whether the domain gets mentioned in AI answers. Each finding comes with a copy-ready fix prompt. The Schema Validator and AI Access Checker are free and need no account.

Note: the README links to CONTRIBUTING.md but the file isn't in the repo, so I followed the format of the existing entries. Happy to adjust.

Disclosure: I'm the founder.